### PR TITLE
Improves Docker dev setup with healthchecks, volumes, and launch config.

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,29 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "Rails Server",
+      "runtimeExecutable": "bin/rails",
+      "runtimeArgs": ["server", "-p", "3000", "-b", "0.0.0.0"],
+      "port": 3000
+    },
+    {
+      "name": "Docker: Full Stack",
+      "runtimeExecutable": "docker",
+      "runtimeArgs": ["compose", "up"],
+      "port": 3000
+    },
+    {
+      "name": "Docker: MySQL",
+      "runtimeExecutable": "docker",
+      "runtimeArgs": ["compose", "up", "db"],
+      "port": 3307
+    },
+    {
+      "name": "Docker: Redis",
+      "runtimeExecutable": "docker",
+      "runtimeArgs": ["compose", "up", "redis"],
+      "port": 6379
+    }
+  ]
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Git
+.git
+.gitignore
+
+# Logs and temp files
+log/*
+tmp/*
+storage/*
+
+# Test artifacts
+spec/reports
+coverage
+
+# Editor files
+.vscode
+.idea
+*.swp
+*.swo
+
+# Docker files themselves (no recursion needed)
+.dockerignore
+docker-compose*.yml
+
+# Secrets — NEVER copy these into an image
+config/master.key
+config/credentials/*.key
+.env
+.env.*
+
+# Node / assets build artifacts (generated at build time)
+node_modules
+public/assets
+public/packs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,30 +3,51 @@ services:
     image: mysql:8.0
     environment:
       MYSQL_ROOT_PASSWORD: root
-      MYSQL_DATABASE: caffeine_monster
+      MYSQL_DATABASE: caffeine_monster_development
     ports:
       - "3307:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-proot"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
   redis:
-    image: redis:8.6.2
+    image: redis:7-alpine
     ports:
-    - "6379:6379"
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+
   web:
     build:
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: Dockerfile-dev
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     environment:
-      DATABASE_NAME: caffeine_monster
+      DATABASE_NAME: caffeine_monster_development
       DATABASE_PASSWORD: root
       DATABASE_HOST: db
       DATABASE_PORT: 3306
+      REDIS_URL: redis://redis:6379/0
       RAILS_MASTER_KEY: ${RAILS_MASTER_KEY}
-      REDIS_URL: ${REDIS_URL}
-    working_dir: /myapp
+    working_dir: /rails
     volumes:
-      - .:/myapp
+      - .:/rails
+      - bundle_cache:/usr/local/bundle
     stdin_open: true
     tty: true
     ports:
       - "3000:3000"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
+
+volumes:
+  mysql_data:
+  redis_data:
+  bundle_cache:


### PR DESCRIPTION
- Fixes working_dir mismatch (myapp → rails) in docker-compose.yml
- Adds named volumes for MySQL, Redis, and bundle cache persistence
- Adds MySQL healthcheck to prevent Rails startup race condition
- Switches web service to use Dockerfile-dev for development
- Adds hardcoded REDIS_URL instead of requiring env var
- Adds .dockerignore to prevent secrets/logs from leaking into images
- Adds .claude/launch.json with detected dev server configurations