### PR TITLE
Adds stored procedure for money transfer.

### DIFF
--- a/app/services/money_transfer_service.rb
+++ b/app/services/money_transfer_service.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+# Transfers money between two accounts using the +transferAmount+ stored procedure.
+#
+# Validates that the transfer amount is positive and the source and destination
+# accounts are different before delegating to the database procedure.
+#
+# == Usage
+#
+#   result = MoneyTransferService.call(1, 2, '50.00')
+#   if result.success?
+#     puts result.data[:message]  # => "Transfer successful"
+#   else
+#     puts result.error[:message] # => "Insufficient balance"
+#   end
+#
+class MoneyTransferService < BaseService
+  attr_reader :from_account_id, :to_account_id, :amount
+
+  # Creates a new MoneyTransferService instance.
+  #
+  # All three arguments are required; raises +ArgumentError+ if any is +nil+.
+  # +from_account_id+ and +to_account_id+ are coerced to Integer,
+  # and +amount+ is coerced to BigDecimal.
+  #
+  # +from_account_id+ - the id of the source Account
+  # +to_account_id+   - the id of the destination Account
+  # +amount+          - the transfer amount (String, Integer, or BigDecimal)
+  #
+  # Raises +ArgumentError+ if any argument is +nil+ or cannot be coerced
+  def initialize(from_account_id, to_account_id, amount)
+    super()
+    if [from_account_id, to_account_id, amount].any?(&:nil?)
+      raise ArgumentError, 'from_account_id, to_account_id, amount are required'
+    end
+
+    @from_account_id = Integer(from_account_id)
+    @to_account_id = Integer(to_account_id)
+    @amount = BigDecimal(amount.to_s)
+  end
+
+  # Executes the money transfer.
+  #
+  # Returns a +Response+ with <tt>{ message: 'Transfer successful' }</tt> on success.
+  # Returns a +Response+ with an error hash on failure, including:
+  # - <tt>'Transfer amount must be positive'</tt> — when +amount+ is zero or negative
+  # - <tt>'Cannot transfer to the same account'</tt> — when source equals destination
+  # - <tt>'Insufficient balance'</tt> — when the source account lacks funds
+  # - <tt>'One or both accounts do not exist'</tt> — when an account id is invalid
+  # - <tt>'Transfer failed. Please try again later.'</tt> — for unexpected database errors
+  def call
+    return Response.new(nil, { message: 'Transfer amount must be positive' }) unless amount.positive?
+    return Response.new(nil, { message: 'Cannot transfer to the same account' }) if from_account_id == to_account_id
+
+    execute_transfer
+    Response.new({ message: 'Transfer successful' })
+  rescue ActiveRecord::StatementInvalid => e
+    Response.new(nil, { message: transfer_error_message(e) })
+  end
+
+  private
+
+  # Calls the +transferAmount+ MySQL stored procedure with sanitized parameters.
+  def execute_transfer
+    sanitized_sql = ActiveRecord::Base.sanitize_sql_array(
+      ['CALL transferAmount(?, ?, ?)', from_account_id, to_account_id, amount]
+    )
+    ActiveRecord::Base.connection.execute(sanitized_sql)
+  end
+
+  # Maps database error messages to user-friendly strings.
+  #
+  # +exception+ - an ActiveRecord::StatementInvalid wrapping the database error
+  def transfer_error_message(exception)
+    db_message = exception.cause&.message.to_s
+
+    case db_message
+    when /Insufficient Balance/i then 'Insufficient balance'
+    when /do not exist/i then 'One or both accounts do not exist'
+    else
+      Rails.logger.error("Money transfer failed: #{db_message}")
+      'Transfer failed. Please try again later.'
+    end
+  end
+end

--- a/db/migrate/20260415063704_adds_money_transfer_query.rb
+++ b/db/migrate/20260415063704_adds_money_transfer_query.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# Adds money transfer script for atomicity
+class AddsMoneyTransferQuery < ActiveRecord::Migration[7.1]
+  SQL = <<~SQL
+      CREATE PROCEDURE IF NOT EXISTS transferAmount(
+        IN from_account_id INT,
+        IN to_account_id INT,
+        IN amount DECIMAL(10,2)
+      )
+    BEGIN
+        DECLARE current_amount DECIMAL(10,2);
+        DECLARE account_count INT;
+
+        DECLARE EXIT HANDLER FOR SQLEXCEPTION
+        BEGIN
+            ROLLBACK;
+            RESIGNAL;
+        END;
+
+        -- Validate inputs
+        IF amount <= 0 THEN
+            SIGNAL SQLSTATE '45000'
+            SET MESSAGE_TEXT = 'Transfer amount must be positive';
+        END IF;
+
+        IF from_account_id = to_account_id THEN
+            SIGNAL SQLSTATE '45000'
+            SET MESSAGE_TEXT = 'Cannot transfer to the same account';
+        END IF;
+
+        START TRANSACTION;
+
+            -- Lock in consistent order (lower ID first) to prevent deadlocks
+            SELECT COUNT(*) INTO account_count
+            FROM accounts
+            WHERE id IN (from_account_id, to_account_id)
+            ORDER BY id
+            FOR UPDATE;
+
+            IF account_count < 2 THEN
+                SIGNAL SQLSTATE '45000'
+                SET MESSAGE_TEXT = 'One or both accounts do not exist';
+            END IF;
+
+            -- Balance already locked from above
+            SELECT balance INTO current_amount
+            FROM accounts
+            WHERE id = from_account_id;
+
+            IF current_amount < amount THEN
+                SIGNAL SQLSTATE '45000'
+                SET MESSAGE_TEXT = 'Insufficient Balance';
+            END IF;
+
+            UPDATE accounts SET balance = balance - amount, updated_at = NOW() WHERE id = from_account_id;
+            UPDATE accounts SET balance = balance + amount, updated_at = NOW() WHERE id = to_account_id;
+
+        COMMIT;
+    END
+  SQL
+
+  def up
+    ActiveRecord::Base.connection.exec_query(SQL)
+  end
+
+  def down
+    ActiveRecord::Base.connection.exec_query('DROP PROCEDURE IF EXISTS transferAmount')
+  end
+end

--- a/spec/services/money_transfer_service_spec.rb
+++ b/spec/services/money_transfer_service_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MoneyTransferService, type: :service do
+  describe '#call' do
+    let(:from_account_id) { create(:account).id }
+    let(:to_account_id) { create(:account).id }
+    let(:amount) { 500 }
+
+    context 'when transfer is successful' do
+      it 'returns a successful response' do
+        from_account = Account.find(from_account_id)
+        to_account = Account.find(to_account_id)
+        initial_balance_of_from_account = from_account.balance
+        initial_balance_of_to_account = to_account.balance
+        response = described_class.call(from_account_id, to_account_id, amount)
+
+        expect(response.success?).to be true
+        expect(response.data).to eq({ message: 'Transfer successful' })
+        expect(response.error).to be_nil
+        expect(from_account.reload.balance).to eq(initial_balance_of_from_account - amount)
+        expect(to_account.reload.balance).to eq(initial_balance_of_to_account + amount)
+      end
+    end
+
+    context 'when the stored procedure raises a Mysql2::Error' do
+      it 'returns a failed response with the error message' do
+        account_balance = Account.find(from_account_id).balance
+        response = described_class.call(from_account_id, to_account_id, account_balance + 100)
+        expect(response.success?).to be false
+        expect(response.data).to be_nil
+        expect(response.error).to eq({ message: 'Insufficient balance' })
+      end
+    end
+
+    context 'when called via class-level .call' do
+      it 'instantiates and calls the service' do
+        response = described_class.call(from_account_id, to_account_id, amount)
+
+        expect(response.success?).to be true
+        expect(response.data).to eq({ message: 'Transfer successful' })
+      end
+    end
+  end
+
+  describe '#initialize' do
+    context 'when from_account_id is nil' do
+      it 'raises an error' do
+        expect { described_class.new(nil, 2, 500) }
+          .to raise_error('from_account_id, to_account_id, amount are required')
+      end
+    end
+
+    context 'when to_account_id is nil' do
+      it 'raises an error' do
+        expect { described_class.new(1, nil, 500) }
+          .to raise_error('from_account_id, to_account_id, amount are required')
+      end
+    end
+
+    context 'when amount is nil' do
+      it 'raises an error' do
+        expect { described_class.new(1, 2, nil) }
+          .to raise_error('from_account_id, to_account_id, amount are required')
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Money Transfer Feature

Implements atomic balance transfers between accounts using a MySQL stored procedure called from a Rails service object.

---

## Files

### `db/migrate/20260415063704_adds_money_transfer_query.rb`

Creates (and drops on rollback) the `transferAmount` MySQL stored procedure.

**Procedure signature:**
```sql
CALL transferAmount(from_account_id INT, to_account_id INT, amount DECIMAL(10,2));
```

**What it does:**

1. Validates inputs before opening a transaction — signals `SQLSTATE '45000'` if `amount <= 0` or if both account IDs are the same.
2. Opens a transaction and locks both account rows with `SELECT … FOR UPDATE`, acquiring locks in ascending `id` order to prevent deadlocks on concurrent transfers between the same pair of accounts.
3. Signals `SQLSTATE '45000'` (`One or both accounts do not exist`) if fewer than two rows are found.
4. Reads the source balance and signals `SQLSTATE '45000'` (`Insufficient Balance`) if it is less than `amount`.
5. Debits `from_account_id` and credits `to_account_id`, stamping `updated_at = NOW()` on both rows.
6. A `DECLARE EXIT HANDLER FOR SQLEXCEPTION` rolls back and re-raises on any unexpected SQL error.

**Running the migration:**
```bash
bin/rails db:migrate
bin/rails db:migrate:down VERSION=20260415063704  # drops the procedure
```

---

### `app/services/money_transfer_service.rb`

Service object that wraps the stored procedure call. Inherits from `BaseService`, which provides the `Response` struct (`data`, `error`, `success?`) and the class-level `.call` shorthand.

**Usage:**
```ruby
result = MoneyTransferService.call(from_account_id, to_account_id, '50.00')
if result.success?
  puts result.data[:message]   # => "Transfer successful"
else
  puts result.error[:message]  # => "Insufficient balance"
end
```

**Initializer** — coerces and validates arguments:
- Raises `ArgumentError` if any argument is `nil`
- Coerces `from_account_id` / `to_account_id` to `Integer`
- Coerces `amount` to `BigDecimal` (via `.to_s` to handle numeric types safely)

**`#call`** — business logic guard clauses, then delegates to the database:

| Condition | Response |
|-----------|----------|
| `amount <= 0` | failure — `'Transfer amount must be positive'` |
| `from_account_id == to_account_id` | failure — `'Cannot transfer to the same account'` |
| DB signals `Insufficient Balance` | failure — `'Insufficient balance'` |
| DB signals `do not exist` | failure — `'One or both accounts do not exist'` |
| Unexpected DB error | failure — `'Transfer failed. Please try again later.'` (logged) |
| Success | `{ message: 'Transfer successful' }` |

**`execute_transfer`** — builds a sanitized SQL string via `sanitize_sql_array` and calls `ActiveRecord::Base.connection.execute`.

**`transfer_error_message`** — maps `ActiveRecord::StatementInvalid` cause messages to user-facing strings; unexpected errors are logged with `Rails.logger.error`.

---

### `spec/services/money_transfer_service_spec.rb`

RSpec integration tests. Uses real database records (FactoryBot) and the live stored procedure — no mocking of the DB layer.

**Coverage:**

| Context | What is tested |
|---------|---------------|
| Successful transfer | Response is successful; source balance decreases; destination balance increases |
| Insufficient balance | Triggers the stored procedure's `Insufficient Balance` signal; returns failure response |
| Class-level `.call` | Delegates correctly through `BaseService` |
| `nil` `from_account_id` | `initialize` raises `ArgumentError` |
| `nil` `to_account_id` | `initialize` raises `ArgumentError` |
| `nil` `amount` | `initialize` raises `ArgumentError` |

**Running the tests:**
```bash
bundle exec rspec spec/services/money_transfer_service_spec.rb
```
